### PR TITLE
Menu link validation

### DIFF
--- a/src/js/_enqueues/lib/nav-menu.js
+++ b/src/js/_enqueues/lib/nav-menu.js
@@ -589,8 +589,11 @@
 		},
 
 		initPreviewing : function() {
+
+			const menuToEdit = $( '#menu-to-edit' );
+
 			// Update the item handle title when the navigation label is changed.
-			$( '#menu-to-edit' ).on( 'change input', '.edit-menu-item-title', function(e) {
+			menuToEdit.on( 'change input', '.edit-menu-item-title', function(e) {
 				var input = $( e.currentTarget ), title, titleEl;
 				title = input.val();
 				titleEl = input.closest( '.menu-item' ).find( '.menu-item-title' );
@@ -599,6 +602,26 @@
 					titleEl.text( title ).removeClass( 'no-title' );
 				} else {
 					titleEl.text( wp.i18n._x( '(no label)', 'missing menu item navigation label' ) ).addClass( 'no-title' );
+				}
+			} );
+
+			// Show warning when url is empty/invalid in custom menu item type.
+			menuToEdit.on( 'change input', '.edit-menu-item-url', function( e ) {
+
+				const input = $( e.currentTarget );
+				const url = input.val();
+				const urlEl = input.closest( '.menu-item' ).find( '.field-url' );
+
+				if ( '' === url || 'https://' === url || 'http://' === url ) {
+
+					urlEl.addClass( 'form-invalid' );
+					urlEl.attr( 'placeholder', 'https://' );
+
+				} else {
+
+					urlEl.removeClass( 'form-invalid' );
+					urlEl.attr( 'placeholder', '' );
+
 				}
 			} );
 		},
@@ -1063,12 +1086,35 @@
 		},
 
 		attachMenuSaveSubmitListeners : function() {
+			const updateNavMenuEl = $( '#update-nav-menu' );
+
 			/*
 			 * When a navigation menu is saved, store a JSON representation of all form data
 			 * in a single input to avoid PHP `max_input_vars` limitations. See #14134.
 			 */
-			$( '#update-nav-menu' ).on( 'submit', function() {
-				var navMenuData = $( '#update-nav-menu' ).serializeArray();
+			updateNavMenuEl.on( 'submit', function() {
+
+				// Stop saving of menu if it has invalid field.
+				if ( updateNavMenuEl.has( '.form-invalid' ).length > 0 ) {
+
+					updateNavMenuEl.find( '.form-invalid' ).each( function () {
+
+						const menuItem = $( this ).closest( '.menu-item' );
+
+						// Open all the menu items containing invalid fields.
+						if( menuItem.hasClass( 'menu-item-edit-inactive' ) ) {
+
+							menuItem.find( '.menu-item-settings' ).slideDown( 'fast' );
+							menuItem.removeClass('menu-item-edit-inactive')
+								.addClass('menu-item-edit-active');
+
+						}
+					} );
+
+					return false;
+				}
+
+				var navMenuData = updateNavMenuEl.serializeArray();
 				$( '[name="nav-menu-data"]' ).val( JSON.stringify( navMenuData ) );
 			});
 		},

--- a/src/wp-admin/includes/class-walker-nav-menu-edit.php
+++ b/src/wp-admin/includes/class-walker-nav-menu-edit.php
@@ -196,7 +196,7 @@ class Walker_Nav_Menu_Edit extends Walker_Nav_Menu {
 					<p class="field-url description description-wide">
 						<label for="edit-menu-item-url-<?php echo $item_id; ?>">
 							<?php _e( 'URL' ); ?><br />
-							<input type="text" id="edit-menu-item-url-<?php echo $item_id; ?>" class="widefat code edit-menu-item-url" name="menu-item-url[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $menu_item->url ); ?>" />
+							<input type="text" id="edit-menu-item-url-<?php echo $item_id; ?>" class="widefat code form-required edit-menu-item-url" name="menu-item-url[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $menu_item->url ); ?>" placeholder="https://" />
 						</label>
 					</p>
 				<?php endif; ?>

--- a/src/wp-admin/includes/nav-menu.php
+++ b/src/wp-admin/includes/nav-menu.php
@@ -1427,7 +1427,7 @@ function wp_nav_menu_update_menu_items( $nav_menu_selected_id, $nav_menu_selecte
 
 			// Menu item URL can't be blank.
 			if ( isset( $_POST['menu-item-type'][ $_key ] ) && 'custom' === $_POST['menu-item-type'][ $_key ] && '' === $_POST['menu-item-url'][ $_key ] ) {
-                continue;
+				continue;
 			}
 
 			$args = array();

--- a/src/wp-admin/includes/nav-menu.php
+++ b/src/wp-admin/includes/nav-menu.php
@@ -1425,6 +1425,11 @@ function wp_nav_menu_update_menu_items( $nav_menu_selected_id, $nav_menu_selecte
 				continue;
 			}
 
+			// Menu item URL can't be blank.
+			if ( isset( $_POST['menu-item-type'][ $_key ] ) && 'custom' === $_POST['menu-item-type'][ $_key ] && '' === $_POST['menu-item-url'][ $_key ] ) {
+                continue;
+			}
+
 			$args = array();
 			foreach ( $post_fields as $field ) {
 				$args[ $field ] = isset( $_POST[ $field ][ $_key ] ) ? $_POST[ $field ][ $_key ] : '';


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

## Description
- This PR adds URL validation to the `Custom Link` menu items.

## Steps to reproduce Bug

- If we try adding `Custom Link` with an empty URL in the Menu, We get a validation error & are not able to add `Custom Link`.

  https://github.com/Pathan-Amaankhan/wordpress-develop/assets/63953699/80590807-8df8-45d6-9261-2ab8535e0fb3

- But if we try the same after adding `Custom Link` to the Menu, we don't get the validation error & can add `Custom Link` with an empty URL. This breaches the consistency.

  https://github.com/Pathan-Amaankhan/wordpress-develop/assets/63953699/e36f3b2b-09be-4db4-9baa-81346756f2e8


## Expected behaviour
- A validation error should be shown if we add `Custom Link` with an empty URL.

## Screenshots/Screencasts

#### Before

- Able to save `Custom Link` with an empty URL.

  https://github.com/Pathan-Amaankhan/wordpress-develop/assets/63953699/e36f3b2b-09be-4db4-9baa-81346756f2e8

#### After
- A validation error is displayed if we try to save `Custom Link` with an empty URL.

  https://github.com/Pathan-Amaankhan/wordpress-develop/assets/63953699/11e32112-096a-46eb-afee-efb134a5dd8d



---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
